### PR TITLE
Update cst.c

### DIFF
--- a/util/GRASS/cst/cst.c
+++ b/util/GRASS/cst/cst.c
@@ -661,8 +661,8 @@ bool printStream(streamEntry *currentStreamPtr, FILE *streamOutFile, streamEntry
     if (debug)
         printf("Printing stream %d\n", currentStreamPtr->streamId);
 
-    fprintf(streamOutFile, "\n%d %7.2f %7.2f %7.2f %7.4f %7.4f %7.2f\n", currentStreamPtr->streamId, currentStreamPtr->streamBottomWidth,
-            currentStreamPtr->streamTopWidth, currentStreamPtr->streamDepth, currentStreamPtr->slope, currentStreamPtr->ManningsN, currentStreamPtr->pixelCount*cellResolution);
+    fprintf(streamOutFile, "\n%d %7.2f %7.2f %7.2f %7.4f %7.4f %7.2f\n", currentStreamPtr->streamId, currentStreamPtr->streamTopWidth, currentStreamPtr->streamBottomWidth,
+            currentStreamPtr->streamDepth, currentStreamPtr->slope, currentStreamPtr->ManningsN, currentStreamPtr->pixelCount*cellResolution);
     fprintf(streamOutFile, "%d\n", currentStreamPtr->basinDivisionCnt);
 
     int j;


### PR DESCRIPTION
Switching the order of currentStreamPtr->streamTopWidth and currentStreamPtr->streamBottomWidth when they're written out to stream table file so that construct_stream_routing_topology.c (line 119 to 127) will correctly read stream topology