### PR TITLE
Fix stream sorting

### DIFF
--- a/rhessys/init/construct_stream_routing_topology.c
+++ b/rhessys/init/construct_stream_routing_topology.c
@@ -200,10 +200,10 @@ struct stream_list_object construct_stream_routing_topology(
 	
 	m=num_reaches-2;
 	for(i=num_reaches-1;i>=0;--i){
-		for (j=0; j< stream_network[i].num_upstream_neighbours; ++j) {
+		for (j=0; j< stream_network_ini[i].num_upstream_neighbours; ++j) {
 			for(k=0; k< num_reaches; ++k){
 				
-				if(stream_network[i].upstream_neighbours[j]==stream_network_ini[k].reach_ID){
+				if(stream_network_ini[i].upstream_neighbours[j]==stream_network_ini[k].reach_ID){
 					stream_network[m]=stream_network_ini[k];
 					m=m-1;
 					break;


### PR DESCRIPTION
The stream sorting algorithm was relying on checks made to the variable **stream_network** instead of **stream_network_ini**.

At this point in the code **stream_network** is completely uninitialized, and so the comparison always fails.

A quick sanity check is to put a **printf** inside of the check for the reach_ID and run the model with stream routing turned on.