### PR TITLE
update compute_xylem_conductance

### DIFF
--- a/rhessys/hydro/compute_xylem_conductance.c
+++ b/rhessys/hydro/compute_xylem_conductance.c
@@ -50,7 +50,7 @@ void	compute_xylem_conductance(
 
 	if ((LWP_predawn < epc.LWP_gxylem_min) && (stratum[0].gs_sunlit >= epc.gxylem_min_gs) && 
 				(stratum[0].gs_shade >= epc.gxylem_min_gs)) {
-	stratum[0].gxylem = epc.gxylem_max * exp(pow( (-1.0*LWP_predawn/epc.gxylem_bsat),epc.gxylem_csat));
+	stratum[0].gxylem = epc.gxylem_max * exp(-1.0*pow( (-1.0*LWP_predawn/epc.gxylem_bsat),epc.gxylem_csat));
 	}
 
 


### PR DESCRIPTION
typo in equation 11 of Mackay et al., 2015. see trees code below. 

ks[i][1] = xylemScalar*ksat[i][1] * exp(-pow((-psimin[i][1] / bsat[i][1]), ccsat[i][1]))