### PR TITLE
Fix incorrect readFormat passed into getIntWorldfile()

### DIFF
--- a/rhessys/init/construct_canopy_strata.c
+++ b/rhessys/init/construct_canopy_strata.c
@@ -263,7 +263,7 @@ struct canopy_strata_object *construct_canopy_strata(
 	fscanf(world_file,"%lf",&(canopy_strata[0].epv.min_vwc));
 	read_record(world_file, record);*/
 	
-	canopy_strata[0].epv.wstress_days  = getIntWorldfile(&paramCnt,&paramPtr,"epv.wstress_days","%lf",0,1);
+	canopy_strata[0].epv.wstress_days  = getIntWorldfile(&paramCnt,&paramPtr,"epv.wstress_days","%d",0,1);
 
 	canopy_strata[0].epv.max_fparabs = getDoubleWorldfile(&paramCnt,&paramPtr,"epv.max_fparabs","%lf",0.0,1);
 	


### PR DESCRIPTION
Okay, so this is weird.

The following line:
```
canopy_strata[0].epv.wstress_days  = getIntWorldfile(&paramCnt,&paramPtr,"epv.wstress_days","%lf",0,1);
```
[See source](https://github.com/RHESSys/RHESSys/blob/24e8710ece9039682ee8a1a7435eb192e46958f3/rhessys/init/construct_canopy_strata.c#L266)

was incorrectly passing `"%lf"`as the `readFormat` to getIntWorldfile (instead of `"%d"`).

This is not a problem on Intel with/without optimizations enabled (`-O2`), or on ARM (AppleSilicon) when optimizations are not enabled. However, when optimizations were turned on for ARM (`-O1` or `-O2`), the above line caused SIGSEGV in the call to `getDoubleWorldfile()` that follows the above call to `getIntWorldfile()`:
```
canopy_strata[0].epv.max_fparabs = getDoubleWorldfile(&paramCnt,&paramPtr,"epv.max_fparabs","%lf",0.0,1);
```
[See source](https://github.com/RHESSys/RHESSys/blob/24e8710ece9039682ee8a1a7435eb192e46958f3/rhessys/init/construct_canopy_strata.c#L268)

In the optimized version of the code on ARM, `readFormat` was passed into `getDoubleWorldfile()` as an empty string (`""`) after the erroneous call to `getIntWorldfile()`.

I didn't take the time to compare the disassembled versions of the code with/without optimizations, but this seems like it may be a compiler bug.

With the change in this PR, I was able to run my local test model on AppleSilicon with a rhessys binary compiled with `-O2`. The output produced is identical to the output produced on Intel. Incidentally, the model run took 16 seconds on my M1 AppleSilicon, but 42 seconds on my MacBook Pro with 2.3 GHz I9-9880H.


