### PR TITLE
Fixed many types of compiler warnings

### DIFF
--- a/rhessys/cn/allocate_daily_growth.c
+++ b/rhessys/cn/allocate_daily_growth.c
@@ -110,8 +110,9 @@ int allocate_daily_growth(int nlimit,
 	froot = cdf->froot;
 	fwood = cdf->fwood;
 
-	if (cdf->fcroot > ZERO);
+	if (cdf->fcroot > ZERO){
 		fcroot = cdf->fcroot;
+	}
 
 	if ((fleaf + froot) > ZERO) {
 

--- a/rhessys/cn/compute_annual_turnover.c
+++ b/rhessys/cn/compute_annual_turnover.c
@@ -46,7 +46,7 @@ int compute_annual_turnover(
 	/*------------------------------------------------------*/
 	
 	int ok=1;
-	if ( (epc.veg_type == TREE) ){
+	if ( epc.veg_type == TREE ){
 		epv->day_livestem_turnover = (cs->live_stemc
 			+ cs->livestemc_transfer + cs->livestemc_store)
 			* epc.livewood_turnover / 365;

--- a/rhessys/cn/compute_potential_N_uptake_combined.c
+++ b/rhessys/cn/compute_potential_N_uptake_combined.c
@@ -147,7 +147,7 @@ double compute_potential_N_uptake_combined(
 		fbroot = fleaf * epc.alloc_frootc_leafc *  (1+epc.waring_pb )/ (1.0 + epc.waring_pb * (cdf->psn_to_cpool)/c);
 		ratio = fbroot/fleaf;
 
-		if ((epc.veg_type == TREE)) {
+		if (epc.veg_type == TREE) {
 		if (fbroot+fleaf > 0.95) {
 			fleaf = 0.95/(1+ratio);
 			fbroot = fleaf*ratio;

--- a/rhessys/cn/update_decomp.c
+++ b/rhessys/cn/update_decomp.c
@@ -424,7 +424,7 @@ int update_decomp(
 		+ ns_litr->litr4n + ns_soil->soil1n + ns_soil->soil2n
 		+ ns_soil->soil3n + ns_soil->soil4n + ns_soil->sminn + ns_soil->nitrate;
 	balance = (total_preday_N)  - (total_N + ndf->sminn_to_npool);
-	if (abs(balance) > ZERO)
+	if (fabs(balance) > ZERO)
 		printf("\n Decomp N doesn't balance by %lf ", balance);
 
 	return (!ok);

--- a/rhessys/cycle/canopy_stratum_growth.c
+++ b/rhessys/cycle/canopy_stratum_growth.c
@@ -155,7 +155,7 @@ void	canopy_stratum_growth(
 	/*	be expressed during leaf out				*/
 	/*--------------------------------------------------------------*/
 	if (command_line[0].grow_flag > 0) {
-	if ( (stratum[0].phen.annual_allocation == 1) ){
+	if ( stratum[0].phen.annual_allocation == 1 ){
 		if (allocate_annual_growth(
 			stratum[0].ID,
 			stratum[0].defaults[0][0].ID,

--- a/rhessys/hydro/compute_patch_family_routing.c
+++ b/rhessys/hydro/compute_patch_family_routing.c
@@ -482,10 +482,10 @@ void compute_patch_family_routing(struct zone_object *zone,
             {
                 printf("%f          %f\n",
                     zone[0].patch_families[pf][0].patches[i][0].rz_transfer,
-                    zone[0].patch_families[pf][0].patches[i][0].unsat_transfer,
-                    (zone[0].patch_families[pf][0].patches[i][0].rz_transfer + zone[0].patch_families[pf][0].patches[i][0].unsat_transfer) *
-                    zone[0].patch_families[pf][0].patches[i][0].area,
                     zone[0].patch_families[pf][0].patches[i][0].unsat_transfer
+                    //(zone[0].patch_families[pf][0].patches[i][0].rz_transfer + zone[0].patch_families[pf][0].patches[i][0].unsat_transfer) *
+                    //zone[0].patch_families[pf][0].patches[i][0].area,
+                    //zone[0].patch_families[pf][0].patches[i][0].unsat_transfer
                     );
             }
             printf("==============================\n");

--- a/rhessys/hydro/compute_patch_family_routing.c
+++ b/rhessys/hydro/compute_patch_family_routing.c
@@ -152,8 +152,8 @@ void compute_patch_family_routing(struct zone_object *zone,
 
             // if both sh coefficients are not 0, include patch
             if ((zone[0].patch_families[pf][0].patches[i][0].landuse_defaults[0][0].sh_g > 0 ||
-                 zone[0].patch_families[pf][0].patches[i][0].landuse_defaults[0][0].sh_l > 0) &
-                 zone[0].patch_families[pf][0].num_patches_in_fam > 1 )
+                 zone[0].patch_families[pf][0].patches[i][0].landuse_defaults[0][0].sh_l > 0) &&
+                 zone[0].patch_families[pf][0].num_patches_in_fam > 1)
             {
                 // if sharing coefs > 0, include this patch in subsiquent analyses
                 incl_sat[i] = 1;

--- a/rhessys/hydro/compute_stream_routing.c
+++ b/rhessys/hydro/compute_stream_routing.c
@@ -149,7 +149,7 @@ double count this way */
 
 		/*calulate water depth for next time step */
 		xarea=alfa*pow(stream_network[i].Qin,0.6);
-		stream_network[i].water_depth=(-stream_network[i].bottom_width+sqrt(abs(stream_network[i].bottom_width*stream_network[i].bottom_width+4*tangent*xarea)))/(2*tangent);
+		stream_network[i].water_depth=(-stream_network[i].bottom_width+sqrt(fabs(stream_network[i].bottom_width*stream_network[i].bottom_width+4*tangent*xarea)))/(2*tangent);
         	
 		
 		/*If there is a reservoir in this reach, do reservoir operation */
@@ -247,14 +247,14 @@ double nonlinear_kimetic_wave(double alfa,double Qin,double initial_flow,double 
 		 Qout=alam*qk1+(1-alam)*qk;
 		 f=(dt/dx)*Qout+alfa*pow(Qout,beta)-c;
         
-		 if(abs(f)<=epsi || abs(f)<=epsi0)
+		 if(fabs(f)<=epsi || fabs(f)<=epsi0)
                     goto _jumpout;
-		 if(abs(f)<abs(fk))
+		 if(fabs(f)<fabs(fk))
 			 break;
 	 }
 	 qk=Qout;
 	 if(k>25)
-		 break;}while(abs(f)>epsi);
+		 break;}while(fabs(f)>epsi);
          _jumpout:
          return(Qout);
 

--- a/rhessys/hydro/update_drainage_road.c
+++ b/rhessys/hydro/update_drainage_road.c
@@ -560,7 +560,7 @@ void  update_drainage_road(
 			patch[0].next_stream[0].streamflow_NO3 += (Nout * patch[0].area / patch[0].next_stream[0].area);
 			patch[0].next_stream[0].streamNO3_from_surface += (Nout * patch[0].area / patch[0].next_stream[0].area);
 			patch[0].next_stream[0].hourly[0].streamflow_NO3 += (Nout * patch[0].area / patch[0].next_stream[0].area);
-			patch[0].next_stream[0].hourly[0].streamflow_NO3_from_surface =+ (Nout * patch[0].area / patch[0].next_stream[0].area);
+			patch[0].next_stream[0].hourly[0].streamflow_NO3_from_surface += (Nout * patch[0].area / patch[0].next_stream[0].area);
 
 			Nout = (min(1.0, (Qout/ patch[0].detention_store))) * patch[0].surface_NH4;
 			patch[0].surface_NH4  -= Nout;

--- a/rhessys/init/climate_grid_interpolation.c
+++ b/rhessys/init/climate_grid_interpolation.c
@@ -97,7 +97,7 @@ void climate_interpolation(
 
         station_search = world_base_stations[i];
 
-    if ( abs(station_search[0].proj_x -zone[0].x_utm) <= search_x && abs(station_search[0].proj_y -zone[0].y_utm) <= search_y)
+    if (fabs(station_search[0].proj_x -zone[0].x_utm) <= search_x && fabs(station_search[0].proj_y -zone[0].y_utm) <= search_y)
        {
 
             rain_found[count] = station_search[0].daily_clim[0].rain[day];

--- a/rhessys/init/construct_ascii_grid.c
+++ b/rhessys/init/construct_ascii_grid.c
@@ -147,48 +147,45 @@ struct base_station_object **construct_ascii_grid (
 	/*--------------------------------------------------------------*/
 	
 	while (fgets(buffer, sizeof(buffer), base_station_file) != NULL) {
-		if (buffer != NULL) {
-			sscanf(buffer, "%s %s", first, second);
-			
-			if (strcmp(second, "grid_cells") == 0) {
-				num_base_stations = atoi(first);
-				printf("\nYou have %d base stations \n", num_base_stations);
-			}
-
-			if (strcmp(second, "daily_climate_prefix") == 0) {
-				sscanf(first, "%s", daily_clim_prefix);
-				printf("Daily clim is %s \n", daily_clim_prefix);
-				strcpy(old_prefix, daily_clim_prefix);	//copy into prefix holder for using with strcat to open clim files
-			} else if (strcmp(second, "effective_lai") == 0) {
-					sscanf(first, "%s", eff_lai);		
-			} else if (strcmp(second, "screen_height") == 0) {
-				sscanf(first, "%s", screen_height);
-				// Checking for optional climate sequences, store those found in the
-				// optional_flag structs for sending to the appropriate create
-				// clim sequence functions.
-			} else if (strcmp(second, "number_non_critical_daily_sequences") == 0) {
-				int num_daily_optional = strtod(first, NULL);
-				for ( j=0; j < num_daily_optional; ++j ) {
-					fgets(buffer, sizeof(buffer), base_station_file);
-					if (buffer != NULL) {
-						if (strncmp(buffer, "atm_trans",9) == 0 ) {
-							daily_flags.atm_trans = 1;
-						} else if (strncmp(buffer, "CO2",3) == 0) {
-							daily_flags.CO2 = 1;
-						} 
-						else if (strncmp(buffer, "daytime_rain_duration",21) == 0 ) {
-							daily_flags.daytime_rain_duration = 1;
-						} 
-						else if (strncmp(buffer, "ndep_NH4",8) == 0 ) {
-							daily_flags.ndep_NH4 = 1;
-						} 
-						else if (strncmp(buffer, "ndep_NO3",8) == 0 ) {
-							daily_flags.ndep_NO3 = 1;
-						} 
-					}  
-				}
-			} 
+		sscanf(buffer, "%s %s", first, second);
+		
+		if (strcmp(second, "grid_cells") == 0) {
+			num_base_stations = atoi(first);
+			printf("\nYou have %d base stations \n", num_base_stations);
 		}
+
+		if (strcmp(second, "daily_climate_prefix") == 0) {
+			sscanf(first, "%s", daily_clim_prefix);
+			printf("Daily clim is %s \n", daily_clim_prefix);
+			strcpy(old_prefix, daily_clim_prefix);	//copy into prefix holder for using with strcat to open clim files
+		} else if (strcmp(second, "effective_lai") == 0) {
+				sscanf(first, "%s", eff_lai);		
+		} else if (strcmp(second, "screen_height") == 0) {
+			sscanf(first, "%s", screen_height);
+			// Checking for optional climate sequences, store those found in the
+			// optional_flag structs for sending to the appropriate create
+			// clim sequence functions.
+		} else if (strcmp(second, "number_non_critical_daily_sequences") == 0) {
+			int num_daily_optional = strtod(first, NULL);
+			for ( j=0; j < num_daily_optional; ++j ) {
+				if (fgets(buffer, sizeof(buffer), base_station_file) != NULL) {;
+					if (strncmp(buffer, "atm_trans",9) == 0 ) {
+						daily_flags.atm_trans = 1;
+					} else if (strncmp(buffer, "CO2",3) == 0) {
+						daily_flags.CO2 = 1;
+					} 
+					else if (strncmp(buffer, "daytime_rain_duration",21) == 0 ) {
+						daily_flags.daytime_rain_duration = 1;
+					} 
+					else if (strncmp(buffer, "ndep_NH4",8) == 0 ) {
+						daily_flags.ndep_NH4 = 1;
+					} 
+					else if (strncmp(buffer, "ndep_NO3",8) == 0 ) {
+						daily_flags.ndep_NO3 = 1;
+					} 
+				} 
+			}
+		} 
 	}
 
 	

--- a/rhessys/init/construct_ddn_routing_topology.c
+++ b/rhessys/init/construct_ddn_routing_topology.c
@@ -91,7 +91,7 @@ struct routing_list_object *construct_ddn_routing_topology(
 			&zone_ID,
 			&hill_ID);
 		fscanf(routing_file,"%lf %lf %lf", &x,&y,&z);
-		fscanf(routing_file,"%lf %d %d", 
+		fscanf(routing_file,"%lf %d %d %d", 
 			&area,
 			&area,
 			&drainage_type,

--- a/rhessys/init/construct_fire_defaults.c
+++ b/rhessys/init/construct_fire_defaults.c
@@ -196,14 +196,14 @@ struct fire_default *construct_fire_defaults(
                 // and "_stratum.params"
                 if (command_line[0].output_prefix != NULL) {
                     strcat(outFilename, command_line[0].output_prefix);
-                    if (filename != NULL) {
+                    if (strcmp(filename, "") != 0) {
                         strcat(outFilename, "_");
                         strcat(outFilename, filename);
                     }
                     strcat(outFilename, "_fire.params");
                 } 
                 else {
-                    if (filename != NULL) {
+                    if (strcmp(filename, "") != 0) {
                         strcat(outFilename, "_");
                         strcat(outFilename, filename);
                     }

--- a/rhessys/init/construct_fire_grid.c
+++ b/rhessys/init/construct_fire_grid.c
@@ -42,7 +42,7 @@
 /*double calc_patch_area_in_grid(double curMinX,double curMinY,double curMaxX,double curMaxY,double cellMaxX,
 							double cellMaxY,double cellMinX,double cellMinY,double cell_res);*/
 
-struct fire_object **construct_patch_fire_grid (struct world_object *world, struct command_line_object *command_line,struct fire_default def)
+struct fire_patch_object **construct_patch_fire_grid (struct world_object *world, struct command_line_object *command_line,struct fire_default def)
 
 {
 	/*--------------------------------------------------------------*/

--- a/rhessys/init/construct_hillslope_defaults.c
+++ b/rhessys/init/construct_hillslope_defaults.c
@@ -129,14 +129,14 @@ struct hillslope_default *construct_hillslope_defaults(
             // and "_hillslope.params"
             if (command_line[0].output_prefix != NULL) {
                 strcat(outFilename, command_line[0].output_prefix);
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }
                 strcat(outFilename, "_hillslope.params");
             } 
             else {
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }

--- a/rhessys/init/construct_landuse_defaults.c
+++ b/rhessys/init/construct_landuse_defaults.c
@@ -173,14 +173,14 @@ struct landuse_default *construct_landuse_defaults(
             // and "_landuse.params"
             if (command_line[0].output_prefix != NULL) {
                 strcat(outFilename, command_line[0].output_prefix);
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }
                 strcat(outFilename, "_landuse.params");
             } 
             else {
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }

--- a/rhessys/init/construct_netcdf_grid.c
+++ b/rhessys/init/construct_netcdf_grid.c
@@ -222,7 +222,7 @@ struct base_station_object *construct_netcdf_grid (
 
         lat = base_station[0].lat;
         lon = base_station[0].lon;
-        if (command_line[0].ncgridinterp_flag != NULL) {
+        if (command_line[0].ncgridinterp_flag != '\0') {
         utm_zone = command_line[0].utm_zone;
         printf("\n Read in the UTM zone from command line for climate data interpolation, the zone is %d \n", utm_zone);
         }

--- a/rhessys/init/construct_netcdf_header.c
+++ b/rhessys/init/construct_netcdf_header.c
@@ -20,7 +20,11 @@
 #include <float.h>
 #include "rhessys.h"
 
+//unsure why FLT_MAX has been redefined here, default is 10^37 in C99
+#ifndef FLT_MAX
 #define FLT_MAX 1000000000
+#endif
+
 double calc_resolution(const bool geographic_unit,const struct  base_station_object **basestations, const int station_numbers); 
 #ifdef LIU_NETCDF_READER
 /*Get the station numbers from station file                         */

--- a/rhessys/init/construct_netcdf_header.c
+++ b/rhessys/init/construct_netcdf_header.c
@@ -43,12 +43,10 @@ int get_netcdf_station_number(char *base_station_filename)
     }
     fseek(base_station_file,0,SEEK_SET);
     while (fgets(buffer, sizeof(buffer), base_station_file) != NULL) {
-        if (buffer != NULL) {
-            sscanf(buffer, "%s %s", first, second);
-            if (strcmp(second, "grid_cells") == 0) {
-                account = atoi(first);
-                break;
-            }
+        sscanf(buffer, "%s %s", first, second);
+        if (strcmp(second, "grid_cells") == 0) {
+            account = atoi(first);
+            break;
         }
     }
     fclose(base_station_file);
@@ -119,119 +117,117 @@ struct base_station_ncheader_object *construct_netcdf_header (
 	fseek(base_station_file,0,SEEK_SET);	
 	baseid = -1;
 	while (fgets(buffer, sizeof(buffer), base_station_file) != NULL) {
-		if (buffer != NULL) {
-			sscanf(buffer, "%s %s", first, second);
-            /*if(strcmp(second,"location_searching_distance") == 0){
-            base_station_ncheader[0].sdist = atof(first);
-            } else */
-            if (strcmp(second, "year_start_index") == 0){
-                base_station_ncheader[0].year_start = atoi(first);
-            } else if (strcmp(second, "day_offset") == 0){
-                base_station_ncheader[0].day_offset = atoi(first);
-            } else if (strcmp(second, "leap_year_include") == 0){
-                base_station_ncheader[0].leap_year = atoi(first);
-            } else if (strcmp(second, "precip_multiplier") == 0){
-                base_station_ncheader[0].precip_mult = atof(first);
-            } else if (strcmp(second, "temperature_unit") == 0){
-                base_station_ncheader[0].temperature_unit = first[0];
-            } else if(strcmp(second,"netcdf_var_x") == 0){
-                strcpy(base_station_ncheader[0].netcdf_x_varname,first);
-            } else if(strcmp(second,"netcdf_var_y") == 0){
-                strcpy(base_station_ncheader[0].netcdf_y_varname,first);
-            } else if(strcmp(second,"netcdf_tmax_filename") == 0){
-                strcpy(base_station_ncheader[0].netcdf_tmax_filename,first);
-            } else if(strcmp(second,"netcdf_var_tmax") == 0){
-                strcpy(base_station_ncheader[0].netcdf_tmax_varname,first);
-            } else if(strcmp(second,"netcdf_tmin_filename") == 0){
-                strcpy(base_station_ncheader[0].netcdf_tmin_filename,first);
-            } else if(strcmp(second,"netcdf_var_tmin") == 0){
-                strcpy(base_station_ncheader[0].netcdf_tmin_varname,first);
-            } else if(strcmp(second,"netcdf_rain_filename") == 0){
-                strcpy(base_station_ncheader[0].netcdf_rain_filename,first);
-            } else if(strcmp(second,"netcdf_var_rain") == 0){
-                strcpy(base_station_ncheader[0].netcdf_rain_varname,first);
-            } else if(strcmp(second,"netcdf_elev_filename") == 0){
-                strcpy(base_station_ncheader[0].netcdf_elev_filename,first);
-            } else if(strcmp(second,"netcdf_var_elev") == 0){
-                strcpy(base_station_ncheader[0].netcdf_elev_varname,first);
-                base_station_ncheader[0].elevflag = 1;
-            }
+        sscanf(buffer, "%s %s", first, second);
+        /*if(strcmp(second,"location_searching_distance") == 0){
+        base_station_ncheader[0].sdist = atof(first);
+        } else */
+        if (strcmp(second, "year_start_index") == 0){
+            base_station_ncheader[0].year_start = atoi(first);
+        } else if (strcmp(second, "day_offset") == 0){
+            base_station_ncheader[0].day_offset = atoi(first);
+        } else if (strcmp(second, "leap_year_include") == 0){
+            base_station_ncheader[0].leap_year = atoi(first);
+        } else if (strcmp(second, "precip_multiplier") == 0){
+            base_station_ncheader[0].precip_mult = atof(first);
+        } else if (strcmp(second, "temperature_unit") == 0){
+            base_station_ncheader[0].temperature_unit = first[0];
+        } else if(strcmp(second,"netcdf_var_x") == 0){
+            strcpy(base_station_ncheader[0].netcdf_x_varname,first);
+        } else if(strcmp(second,"netcdf_var_y") == 0){
+            strcpy(base_station_ncheader[0].netcdf_y_varname,first);
+        } else if(strcmp(second,"netcdf_tmax_filename") == 0){
+            strcpy(base_station_ncheader[0].netcdf_tmax_filename,first);
+        } else if(strcmp(second,"netcdf_var_tmax") == 0){
+            strcpy(base_station_ncheader[0].netcdf_tmax_varname,first);
+        } else if(strcmp(second,"netcdf_tmin_filename") == 0){
+            strcpy(base_station_ncheader[0].netcdf_tmin_filename,first);
+        } else if(strcmp(second,"netcdf_var_tmin") == 0){
+            strcpy(base_station_ncheader[0].netcdf_tmin_varname,first);
+        } else if(strcmp(second,"netcdf_rain_filename") == 0){
+            strcpy(base_station_ncheader[0].netcdf_rain_filename,first);
+        } else if(strcmp(second,"netcdf_var_rain") == 0){
+            strcpy(base_station_ncheader[0].netcdf_rain_varname,first);
+        } else if(strcmp(second,"netcdf_elev_filename") == 0){
+            strcpy(base_station_ncheader[0].netcdf_elev_filename,first);
+        } else if(strcmp(second,"netcdf_var_elev") == 0){
+            strcpy(base_station_ncheader[0].netcdf_elev_varname,first);
+            base_station_ncheader[0].elevflag = 1;
+        }
 #ifdef LIU_EXTEND_CLIM_VAR
-            else if (strcmp(second, "rhum_multiplier") == 0){
-                           base_station_ncheader[0].rhum_mult = atof(first);
-            } else if(strcmp(second,"netcdf_huss_filename") == 0){
-                strcpy(base_station_ncheader[0].netcdf_huss_filename,first);
-            } else if(strcmp(second,"netcdf_var_huss") == 0){
-                strcpy(base_station_ncheader[0].netcdf_huss_varname,first);
-            } else if(strcmp(second,"netcdf_rmax_filename") == 0){
-                strcpy(base_station_ncheader[0].netcdf_rmax_filename,first);
-            } else if(strcmp(second,"netcdf_var_rmax") == 0){
-                strcpy(base_station_ncheader[0].netcdf_rmax_varname,first);
-            } else if(strcmp(second,"netcdf_rmin_filename") == 0){
-                strcpy(base_station_ncheader[0].netcdf_rmin_filename,first);
-            } else if(strcmp(second,"netcdf_var_rmin") == 0){
-                strcpy(base_station_ncheader[0].netcdf_rmin_varname,first);
-            } else if(strcmp(second,"netcdf_rsds_filename") == 0){
-                strcpy(base_station_ncheader[0].netcdf_rsds_filename,first);
-            } else if(strcmp(second,"netcdf_var_rsds") == 0){
-                strcpy(base_station_ncheader[0].netcdf_rsds_varname,first);
-            } else if(strcmp(second,"netcdf_was_filename") == 0){
-                strcpy(base_station_ncheader[0].netcdf_was_filename,first);
-            } else if(strcmp(second,"netcdf_var_was") == 0){
-                strcpy(base_station_ncheader[0].netcdf_was_varname,first);
-            }
+        else if (strcmp(second, "rhum_multiplier") == 0){
+                        base_station_ncheader[0].rhum_mult = atof(first);
+        } else if(strcmp(second,"netcdf_huss_filename") == 0){
+            strcpy(base_station_ncheader[0].netcdf_huss_filename,first);
+        } else if(strcmp(second,"netcdf_var_huss") == 0){
+            strcpy(base_station_ncheader[0].netcdf_huss_varname,first);
+        } else if(strcmp(second,"netcdf_rmax_filename") == 0){
+            strcpy(base_station_ncheader[0].netcdf_rmax_filename,first);
+        } else if(strcmp(second,"netcdf_var_rmax") == 0){
+            strcpy(base_station_ncheader[0].netcdf_rmax_varname,first);
+        } else if(strcmp(second,"netcdf_rmin_filename") == 0){
+            strcpy(base_station_ncheader[0].netcdf_rmin_filename,first);
+        } else if(strcmp(second,"netcdf_var_rmin") == 0){
+            strcpy(base_station_ncheader[0].netcdf_rmin_varname,first);
+        } else if(strcmp(second,"netcdf_rsds_filename") == 0){
+            strcpy(base_station_ncheader[0].netcdf_rsds_filename,first);
+        } else if(strcmp(second,"netcdf_var_rsds") == 0){
+            strcpy(base_station_ncheader[0].netcdf_rsds_varname,first);
+        } else if(strcmp(second,"netcdf_was_filename") == 0){
+            strcpy(base_station_ncheader[0].netcdf_was_filename,first);
+        } else if(strcmp(second,"netcdf_var_was") == 0){
+            strcpy(base_station_ncheader[0].netcdf_was_varname,first);
+        }
 #endif
+        #ifdef LIU_NETCDF_READER
+        else if (strcmp(second, "base_station_id") == 0) {
+            baseid++;
+            world[0].base_stations[baseid][0].ID = atoi(first);
+        } else if (strcmp(second, "xc"/*"x_coordinate"*/) == 0) {
+            world[0].base_stations[baseid][0].proj_x = atof(first);
+        } else if (strcmp(second, "yc"/*"y_coordinate"*/) == 0) {
+            world[0].base_stations[baseid][0].proj_y = atof(first);
+        } else if (strcmp(second, "z_coordinate") == 0) {
+            world[0].base_stations[baseid][0].z = atof(first);
+        } else if (strcmp(second, "lon") == 0) {
+            world[0].base_stations[baseid][0].lon = atof(first);
+        } else if (strcmp(second, "lat") == 0) {
+            world[0].base_stations[baseid][0].lat = atof(first);
+        }
+        #endif
+        else if (strcmp(second, "effective_lai") == 0) {
             #ifdef LIU_NETCDF_READER
-            else if (strcmp(second, "base_station_id") == 0) {
-                baseid++;
-                world[0].base_stations[baseid][0].ID = atoi(first);
-            } else if (strcmp(second, "xc"/*"x_coordinate"*/) == 0) {
-                world[0].base_stations[baseid][0].proj_x = atof(first);
-            } else if (strcmp(second, "yc"/*"y_coordinate"*/) == 0) {
-                world[0].base_stations[baseid][0].proj_y = atof(first);
-            } else if (strcmp(second, "z_coordinate") == 0) {
-                world[0].base_stations[baseid][0].z = atof(first);
-            } else if (strcmp(second, "lon") == 0) {
-                world[0].base_stations[baseid][0].lon = atof(first);
-            } else if (strcmp(second, "lat") == 0) {
-                world[0].base_stations[baseid][0].lat = atof(first);
-            }
+            world[0].base_stations[baseid][0].effective_lai = atof(first);
+            #else
+            base_station_ncheader[0].effective_lai = atof(first);
             #endif
-            else if (strcmp(second, "effective_lai") == 0) {
-                #ifdef LIU_NETCDF_READER
-                world[0].base_stations[baseid][0].effective_lai = atof(first);
-                #else
-                base_station_ncheader[0].effective_lai = atof(first);
-                #endif
-            }
-            else if (strcmp(second, "screen_height") == 0) {
-                #ifdef LIU_NETCDF_READER
-                world[0].base_stations[baseid][0].screen_height = atof(first);
-                #else
-                base_station_ncheader[0].screen_height = atof(first);
-                #endif
-            }
-			// NEED TO UPDATE THIS SECTION
-			// Checking for optional climate sequences, store those found in the
-			// optional_flag structs for sending to the appropriate create
-			// clim sequence functions.
-			
-			/*} else if (strcmp(second, "number_non_critical_daily_sequences") == 0) {
-				int num_daily_optional = strtod(first, NULL);
-				for ( j=0; j < num_daily_optional; ++j ) {
-					fgets(buffer, sizeof(buffer), base_station_file);
-					if (buffer != NULL) {
-						if (strcmp(buffer, "atm_trans") == 0 ) {
-							daily_flags.atm_trans = 1;
-						} else if (strcmp(buffer, "CO2") == 0) {
-							daily_flags.CO2 = 1;
-						} 
-						else if (strcmp(buffer, "daytime_rain_duration") ) {
-							daily_flags.daytime_rain_duration = 1;
-						} 
-					}  
-				}*/
-		}
+        }
+        else if (strcmp(second, "screen_height") == 0) {
+            #ifdef LIU_NETCDF_READER
+            world[0].base_stations[baseid][0].screen_height = atof(first);
+            #else
+            base_station_ncheader[0].screen_height = atof(first);
+            #endif
+        }
+        // NEED TO UPDATE THIS SECTION
+        // Checking for optional climate sequences, store those found in the
+        // optional_flag structs for sending to the appropriate create
+        // clim sequence functions.
+        
+        /*} else if (strcmp(second, "number_non_critical_daily_sequences") == 0) {
+            int num_daily_optional = strtod(first, NULL);
+            for ( j=0; j < num_daily_optional; ++j ) {
+                fgets(buffer, sizeof(buffer), base_station_file);
+                if (buffer != NULL) {
+                    if (strcmp(buffer, "atm_trans") == 0 ) {
+                        daily_flags.atm_trans = 1;
+                    } else if (strcmp(buffer, "CO2") == 0) {
+                        daily_flags.CO2 = 1;
+                    } 
+                    else if (strcmp(buffer, "daytime_rain_duration") ) {
+                        daily_flags.daytime_rain_duration = 1;
+                    } 
+                }  
+            }*/
 		}//end_read_basestationfile
         base_station_ncheader[0].resolution_dd = calc_resolution(true,world[0].base_stations,world[0].num_base_stations);
         base_station_ncheader[0].resolution_meter = calc_resolution(false,world[0].base_stations,world[0].num_base_stations);

--- a/rhessys/init/construct_soil_defaults.c
+++ b/rhessys/init/construct_soil_defaults.c
@@ -313,14 +313,14 @@ struct soil_default *construct_soil_defaults(
             // and "_soil.params"
             if (command_line[0].output_prefix != NULL) {
                 strcat(outFilename, command_line[0].output_prefix);
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }
                 strcat(outFilename, "_soil.params");
             } 
             else {
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }

--- a/rhessys/init/construct_soil_defaults.c
+++ b/rhessys/init/construct_soil_defaults.c
@@ -119,7 +119,7 @@ struct soil_default *construct_soil_defaults(
 		    default_object_list[i].active_zone_z = default_object_list[i].soil_depth;
 		}
 
-		if (abs(default_object_list[i].active_zone_z - default_object_list[i].soil_depth) > 0.5) {
+		if (fabs(default_object_list[i].active_zone_z - default_object_list[i].soil_depth) > 0.5) {
 			printf("\nNote that soil depth used for biogeochem cycling (active zone z)");
  			printf("\nis more than 0.5 meter different from hydrologic soil depth");
  			printf("\nfor soil default file: %s\n", default_files[i] );
@@ -160,7 +160,7 @@ struct soil_default *construct_soil_defaults(
 		soil =  default_object_list[i].soil_type.sand
 			+ default_object_list[i].soil_type.silt
 			+ default_object_list[i].soil_type.clay;
-		if  (abs(soil - 1.0) > ZERO) {
+		if  (fabs(soil - 1.0) > ZERO) {
 			fprintf(stderr,
 				"FATAL ERROR:in construct_soil_defaults\n proportion sand, silt, clay = %f\n\n", soil);
 			printf("\n %d -  %f %f %f %f \n",

--- a/rhessys/init/construct_spinup_defaults.c
+++ b/rhessys/init/construct_spinup_defaults.c
@@ -123,14 +123,14 @@ struct spinup_default *construct_spinup_defaults(
                 // and "_stratum.params"
                 if (command_line[0].output_prefix != NULL) {
                     strcat(outFilename, command_line[0].output_prefix);
-                    if (filename != NULL) {
+                    if (strcmp(filename, "") != 0) {
                         strcat(outFilename, "_");
                         strcat(outFilename, filename);
                     }
                     strcat(outFilename, "_spinup.params");
                 }
                 else {
-                    if (filename != NULL) {
+                    if (strcmp(filename, "") != 0) {
                         strcat(outFilename, "_");
                         strcat(outFilename, filename);
                     }

--- a/rhessys/init/construct_stratum_defaults.c
+++ b/rhessys/init/construct_stratum_defaults.c
@@ -477,14 +477,14 @@ struct stratum_default *construct_stratum_defaults(
             // and "_stratum.params"
             if (command_line[0].output_prefix != NULL) {
                 strcat(outFilename, command_line[0].output_prefix);
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }
                 strcat(outFilename, "_stratum.params");
             } 
             else {
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }

--- a/rhessys/init/construct_surface_energy_defaults.c
+++ b/rhessys/init/construct_surface_energy_defaults.c
@@ -118,14 +118,14 @@ struct surface_energy_default *construct_surface_energy_defaults(
                 // and "_stratum.params"
                 if (command_line[0].output_prefix != NULL) {
                     strcat(outFilename, command_line[0].output_prefix);
-                    if (filename != NULL) {
+                    if (strcmp(filename, "") != 0) {
                         strcat(outFilename, "_");
                         strcat(outFilename, filename);
                     }
                     strcat(outFilename, "_surface_energy.params");
                 } 
                 else {
-                    if (filename != NULL) {
+                    if (strcmp(filename, "") != 0) {
                         strcat(outFilename, "_");
                         strcat(outFilename, filename);
                     }

--- a/rhessys/init/construct_world.c
+++ b/rhessys/init/construct_world.c
@@ -366,11 +366,11 @@ struct world_object *construct_world(struct command_line_object *command_line){
 		struct base_station_object **, struct default_object *, 
         struct base_station_ncheader_object *,
         struct world_object *);
-	struct fire_patch_object **construct_patch_fire_grid(struct world_object *, struct command_line_object *,struct fire_default def);
+	struct fire_patch_object **construct_patch_fire_grid(struct world_object *, struct command_line_object *,struct fire_default);
 	struct fire_object **construct_fire_grid(struct world_object *);
 	struct base_station_object **construct_ascii_grid(char *, struct date, struct date);
 	struct base_station_ncheader_object *construct_netcdf_header(struct world_object *, char *);
-	struct base_station_object *construct_netcdf_grid(struct base_station_object *, struct base_station_ncheader *, int *, float, float, float, struct date *, struct date *, struct command_line_object *);
+	struct base_station_object *construct_netcdf_grid(struct base_station_object *, struct base_station_ncheader_object *, int *, float, float, float, struct date *, struct date *, struct command_line_object *);
   void *construct_spinup_thresholds(char *, struct world_object *, struct command_line_object *);	
 	void *alloc(size_t, char *, char *);
 

--- a/rhessys/init/construct_zone_defaults.c
+++ b/rhessys/init/construct_zone_defaults.c
@@ -191,14 +191,14 @@ struct zone_default *construct_zone_defaults(
             // and "_zone.params"
             if (command_line[0].output_prefix != NULL) {
                 strcat(outFilename, command_line[0].output_prefix);
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }
                 strcat(outFilename, "_zone.params");
             }
             else {
-                if (filename != NULL) {
+                if (strcmp(filename, "") != 0) {
                     strcat(outFilename, "_");
                     strcat(outFilename, filename);
                 }

--- a/rhessys/makefile
+++ b/rhessys/makefile
@@ -27,8 +27,8 @@ endif
 # specifically added to be able to use with -w, to supress warnings
 CMD_OPTS +=
 
-CFLAGS = -g -Wall -Wno-implicit-function-pointer-types -std=c99 $(DEFINES) -fno-stack-protector -O -Wno-implicit-function-declaration -Wno-int-conversion
-CFLAGS_NO_C99 = -g -Wno-implicit-function-pointer-types -Wall $(DEFINES) -fno-stack-protector -O -Wno-implicit-function-declaration -Wno-int-conversion $(CMD_OPTS)
+CFLAGS = -g -Wall -Wno-incompatible-function-pointer-types -std=c99 $(DEFINES) -fno-stack-protector -O -Wno-implicit-function-declaration -Wno-int-conversion
+CFLAGS_NO_C99 = -g -Wno-incompatible-function-pointer-types -Wall $(DEFINES) -fno-stack-protector -O -Wno-implicit-function-declaration -Wno-int-conversion $(CMD_OPTS)
 # -Og for debug
 # -O2 for speed
 

--- a/rhessys/output/add_headers.c
+++ b/rhessys/output/add_headers.c
@@ -103,7 +103,7 @@ void add_headers(struct world_output_file_object *world_output_files,
 	/*	Daily 							*/
 	/*--------------------------------------------------------------*/
 	outfile = world_output_files[0].basin[0].daily;
-	fprintf(outfile,"%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n" ,
+	fprintf(outfile,"%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n" ,
 		"day",
 		"month",
 		"year",
@@ -129,11 +129,11 @@ void add_headers(struct world_output_file_object *world_output_files,
 		"gw.Qout",
 		"gw.storage",
 		"detention_store",
-		"%sat_area",
+		"%%sat_area",
 		"litter_store",
 		"litter_capacity",
 		"canopy_store",
-		"%snow_cover",
+		"%%snow_cover",
 		"snow_subl",
 		"trans_var",
 		"acc_trans",
@@ -286,7 +286,7 @@ void add_headers(struct world_output_file_object *world_output_files,
 	/*	Daily 							*/
 	/*--------------------------------------------------------------*/
 	outfile = world_output_files[0].zone[0].daily;
-	  fprintf(outfile,"%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s $s %s\n" ,
+	  fprintf(outfile,"%s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s %s\n" ,
            "day",
            "month",
            "year",

--- a/rhessys/output/output_basin.c
+++ b/rhessys/output/output_basin.c
@@ -165,7 +165,7 @@ void	output_basin(			int routing_flag,
 	alitrc = 0.0;
 	acdrip = 0.0;
 	acga = 0.0;
-	
+	alitter_cap = 0.0;
 
 	for (h=0; h < basin[0].num_hillslopes; h++){
 		hillslope = basin[0].hillslopes[h];

--- a/rhessys/output/output_basin.c
+++ b/rhessys/output/output_basin.c
@@ -425,7 +425,7 @@ void	output_basin(			int routing_flag,
 	var_acctrans /= aarea;
 				
 
-	fprintf(outfile,"%d %d %d %d %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf\n",
+	fprintf(outfile,"%d %d %d %d %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf %lf\n",
 		date.day,
 		date.month,
 		date.year,

--- a/rhessys/output/output_growth_basin.c
+++ b/rhessys/output/output_growth_basin.c
@@ -94,7 +94,7 @@ void	output_growth_basin(
 	aarea =  0.0 ;
 	asoilhr = 0.0;
 	alitrc = 0.0;
-	alitrn = 0.0; asoiln = 0.0; asoiln_noslow;
+	alitrn = 0.0; asoiln = 0.0; asoiln_noslow = 0.0;
 	anitrate = 0.0;
 	asurfaceN = 0.0;
 	asoilc = 0.0; asminn=0.0;

--- a/rhessys/output/output_yearly_canopy_stratum.c
+++ b/rhessys/output/output_yearly_canopy_stratum.c
@@ -51,7 +51,7 @@ void	output_yearly_canopy_stratum( int basinID, int hillID,
 	/*--------------------------------------------------------------*/
 	/*	output variables					*/
 	/*--------------------------------------------------------------*/
-	fprintf(outfile,"%d %d %d %d %d %d %lf %lf %lf %lf %lf %lf \n",
+	fprintf(outfile,"%d %d %d %d %d %d %lf %lf %lf %lf %lf %lf %lf \n",
 		current_date.year,
 		basinID,
 		hillID,

--- a/rhessys/output_filter/output_filter.c
+++ b/rhessys/output_filter/output_filter.c
@@ -965,6 +965,9 @@ void print_output_filter(OutputFilter *f) {
 		case OUTPUT_FILTER_BASIN:
 			fprintf(stderr, "\ttype: basin,\n");
 			break;
+		case OUTPUT_FILTER_ZONE:
+			fprintf(stderr, "\ttype: zone,\n");
+			break;
 		case OUTPUT_FILTER_PATCH:
 			fprintf(stderr, "\ttype: patch,\n");
 			break;

--- a/rhessys/rad/compute_shaded_kdown.c
+++ b/rhessys/rad/compute_shaded_kdown.c
@@ -52,7 +52,7 @@ void    compute_shaded_kdown(   struct  patch_object    *patch,
     /*--------------------------------------------------------------*/
 	/*  Compare horizons to patch family adjusted horizon           */
 	/*--------------------------------------------------------------*/
-    if (patch[0].family_horizon > asin(zone[0].w_horizon) > 0 || patch[0].family_horizon > asin(zone[0].e_horizon) > 0) {
+    if ((patch[0].family_horizon > asin(zone[0].w_horizon) &&  asin(zone[0].w_horizon) > 0) || (patch[0].family_horizon > asin(zone[0].e_horizon) && asin(zone[0].e_horizon) > 0)) {
         // 180 degrees = pi = 3.141593 rad
         // day length/sky in radians
         dayl_rad = PI - asin(zone[0].w_horizon) - asin(zone[0].e_horizon);

--- a/rhessys/rad/compute_subsurface_temperature_profile.c
+++ b/rhessys/rad/compute_subsurface_temperature_profile.c
@@ -26,7 +26,7 @@
 #include "phys_constants.h"
 
 void compute_subsurface_temperature_profile( 
-					  struct surface_energy_profile	*se_profile,
+					  struct surface_energy_object	*se_profile,
 					  struct surface_energy_default	*sedef,
 					  double tsurface,
 					  double rnet,

--- a/rhessys/tec/input_new_strata_thin.c
+++ b/rhessys/tec/input_new_strata_thin.c
@@ -128,7 +128,7 @@ void input_new_strata_thin(
 	/*--------------------------------------------------------------*/
 	int	base_stationID;
 	int	i, dtmp, num_lines;
-	int	default_object_ID;
+	int	default_object_ID = 0;
 	char	record[MAXSTR];
 	double 	rootc, ltmp;
 	struct mortality_struct mort;

--- a/rhessys/tec/update_fuel_treatment_effects.c
+++ b/rhessys/tec/update_fuel_treatment_effects.c
@@ -127,14 +127,14 @@ void update_fuel_treatment_effects(struct zone_object *zone,
                     // try to build in flexibility to allow multiple of each TREATED or UNTREATED, and areas of them can be scaled appropriately
                     // later..
                     // could do this when initing the patch family obj by adding seperate pointer(s) to the treated and untreated patches
-                    if (zone[0].patch_families[pf][0].patches[p][0].family_role == "TREATED") {
+                    if (strcmp (zone[0].patch_families[pf][0].patches[p][0].family_role,"TREATED") == 0) {
                         trt = p;
                         // taking the probs from the treated patch specifically, though it shouldn't matter
                         // im assuming we want to use the max of these two? could sum them maybe to allow for some interactions, could be confusing
                         max_trt_prob = max(zone[0].patch_families[pf][0].patches[trt][0].fuel_treatment.effective_fuel_treatment_prob, 
                             zone[0].patch_families[pf][0].patches[trt][0].fuel_treatment.external_fuel_treatment_prob);
                     } 
-                    else if (zone[0].patch_families[pf][0].patches[p][0].family_role == "UNTREATED") {
+                    else if (strcmp (zone[0].patch_families[pf][0].patches[p][0].family_role, "UNTREATED") ==0 ) {
                         notrt = p;
                     }
                 }


### PR DESCRIPTION
There were around 900 individual warnings, but only around 25 distinct types of warnings. Fixed around 10 of these distinct types. I think these should be safe for the most part (typos etc) but they should still be reviewed, particularly how reading buffers is handled in `construct_ascii_grid.c` and `construct_netcdf_header.c` .  There is also a redefinition of `FLT_MAX` in `construct_netcdf_header.c` that reduces the max float value to 10^9 instead of the default 10^37, which was odd.